### PR TITLE
Update Paddle org README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,12 +1,30 @@
-## Welcome to the team 🙌
+![A banner to introduce this repo. It has the Paddle logo in white on the right of the image, with a dark gradient background.](https://github.com/PaddleHQ/.github-private/assets/25659933/ed83dd43-2207-44e1-aab6-1296bf589d7e)
 
-<!--
+Hello, we're Paddle! 👋 We make [Paddle Billing](https://www.paddle.com/billing?utm_source=dx&utm_medium=paddle-github-org), [Paddle Retain](https://www.paddle.com/retain?utm_source=dx&utm_medium=paddle-github-org), and [ProfitWell Metrics](https://www.paddle.com/profitwell-metrics?utm_source=dx&utm_medium=paddle-github-org).
 
-**Here are some ideas to get you started:**
+With the Paddle platform, you can build faster, scale sooner, and reduce risk — automatically. We take care of payments, localization, and subscription management, with one unified API that does it all.
 
-🙋‍♀️ A short introduction - what is your organization all about?
-👀 Contribution guidelines - how do team members dive in?
-👩‍💻 Useful resources - where do you keep your docs? Is there anything else the team should know?
-🍪 Fun facts - what is your team's favorite snack?
-🧙 Remember, you can do mighty things with the power of [Markdown](https://docs.github.com/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)
--->
+## Plug in Paddle
+
+Listed here, you'll find libraries and tools to make integrating Paddle a pleasure. Use our hand-crafted SDKs to speed up development, and grab our OpenAPI spec to work with the Paddle API as part of your own workflows and tools. You can also find us on [the Postman public API network](https://www.postman.com/paddlehq/workspace/paddle-billing/overview).
+
+## We 💛 open source
+
+As well as tools for integrating Paddle, you'll find tools that we've built and open-sourced here, too.
+
+Like most companies, we use open source software every day at Paddle. Open source helps us ship great products for our customers, as well as making our working lives more enjoyable. We're grateful to the open source community, and look to contribute to projects, host community events in our hubs, and open-source our own tools where we can.
+
+## Learn more
+
+New to Paddle? Check out our dev docs to get started.
+
+* [Paddle Billing dev docs](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-github-org)
+* [Sign up for Paddle Billing](https://login.paddle.com/signup?utm_source=dx&utm_medium=paddle-github-org)
+
+## Join us
+
+We're a digital-first company, with Paddlers from Atlanta to Amsterdam — and everywhere in between!
+
+To learn more about life at Paddle and the problems we solve, check out [posts by developers on our blog](https://www.paddle.com/resources/topic/developers?utm_source=dx&utm_medium=paddle-github-org). 
+
+Interested in becoming a Paddler? We're looking for technical folks who embody our values, see: [Paddle careers](https://www.paddle.com/careers?utm_source=dx&utm_medium=paddle-github-org)

--- a/profile/README.md
+++ b/profile/README.md
@@ -2,7 +2,7 @@
 
 Hello, we're Paddle! 👋 We make [Paddle Billing](https://www.paddle.com/billing?utm_source=dx&utm_medium=paddle-github-org), [Paddle Retain](https://www.paddle.com/retain?utm_source=dx&utm_medium=paddle-github-org), and [ProfitWell Metrics](https://www.paddle.com/profitwell-metrics?utm_source=dx&utm_medium=paddle-github-org).
 
-With the Paddle platform, you can build faster, scale sooner, and reduce risk — automatically. We take care of payments, localization, and subscription management, with one unified API that does it all.
+With the Paddle platform, you can build faster, scale sooner, and reduce risk — automatically. Our API-first platform takes care of payments, localization, and subscription management for you, freeing you up to focus on building great products.
 
 ## Plug in Paddle
 
@@ -13,6 +13,8 @@ Listed here, you'll find libraries and tools to make integrating Paddle a pleasu
 As well as tools for integrating Paddle, you'll find tools that we've built and open-sourced here, too.
 
 Like most companies, we use open source software every day at Paddle. Open source helps us ship great products for our customers, as well as making our working lives more enjoyable. We're grateful to the open source community, and look to contribute to projects, host community events in our hubs, and open-source our own tools where we can.
+
+We believe community contributions make the Paddle platform better for everyone, so we welcome issues and pull requests in all our public repos. 
 
 ## Learn more
 
@@ -25,6 +27,6 @@ New to Paddle? Check out our dev docs to get started.
 
 We're a digital-first company, with Paddlers from Atlanta to Amsterdam — and everywhere in between!
 
-To learn more about life at Paddle and the problems we solve, check out [posts by developers on our blog](https://www.paddle.com/resources/topic/developers?utm_source=dx&utm_medium=paddle-github-org). 
+To learn more about life at Paddle and the problems we solve, check out [blog posts by our dev team](https://www.paddle.com/resources/topic/developers?utm_source=dx&utm_medium=paddle-github-org) and [what we've shipped lately](https://developer.paddle.com/changelog/overview?utm_source=dx&utm_medium=paddle-github-org).
 
-Interested in becoming a Paddler? We're looking for technical folks who embody our values, see: [Paddle careers](https://www.paddle.com/careers?utm_source=dx&utm_medium=paddle-github-org)
+Interested in becoming a Paddler? We're always looking for great people to help us build the billing platform of the future, see: [Paddle careers](https://www.paddle.com/careers?utm_source=dx&utm_medium=paddle-github-org)


### PR DESCRIPTION
Hey team 👋

This PR adds a README to the Paddle org page on GitHub. 

It's in `.github-private`, which means it only shows up to members of the Paddle org. When we're happy, we can move it to `.github` to make it public to the world.

Cheers,
Michael