### PR TITLE
Update README to mirror new dev docs

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,12 +1,14 @@
-![A banner to introduce this repo. It has the Paddle logo in white on the right of the image, with a dark gradient background.](https://github.com/PaddleHQ/.github-private/assets/25659933/ed83dd43-2207-44e1-aab6-1296bf589d7e)
+<img width="1221" alt="Paddle logo, with the text 'the developer-first merchant' of record underheath. On the right is an illustration of a checkout, payment method icons, and a sample webhook." src="https://github.com/user-attachments/assets/feeb07ac-17c9-42ca-ab3c-af4edf86a090" />
 
 Hello, we're Paddle! 👋 We make [Paddle Billing](https://www.paddle.com/billing?utm_source=dx&utm_medium=paddle-github-org), [Paddle Retain](https://www.paddle.com/retain?utm_source=dx&utm_medium=paddle-github-org), and [ProfitWell Metrics](https://www.paddle.com/profitwell-metrics?utm_source=dx&utm_medium=paddle-github-org).
 
-With the Paddle platform, you can build faster, scale sooner, and reduce risk — automatically. Our API-first platform takes care of payments, localization, and subscription management for you, freeing you up to focus on building great products.
+With the Paddle platform, you can build faster, scale sooner, and reduce risk — automatically. Our API-first platform takes care of payments, tax, subscriptions, and metrics, freeing you up to focus on building great products.
 
 ## Plug in Paddle
 
-Listed here, you'll find libraries and tools to make integrating Paddle a pleasure. Use our hand-crafted SDKs to speed up development, and grab our OpenAPI spec to work with the Paddle API as part of your own workflows and tools. You can also find us on [the Postman public API network](https://www.postman.com/paddlehq/workspace/paddle-billing/overview).
+Listed here, you'll find libraries and tools to make integrating Paddle a pleasure. Use our hand-crafted SDKs to speed up development, and grab our OpenAPI spec to work with the Paddle API as part of your own workflows and tools. You can also find us on [the Postman public API network](https://god.gw.postman.com/run-collection/29428794-16aca740-3ad6-4c1a-97be-05dbc504b4c3?action=collection/fork&source=rip_markdown&collection-url=entityId%3D29428794-16aca740-3ad6-4c1a-97be-05dbc504b4c3%26entityType%3Dcollection%26workspaceId%3D5ed2587a-f47e-43e0-810c-0c3e782bca12#?env[Sandbox]=W3sia2V5IjoiYmFzZVVybCIsInZhbHVlIjoiaHR0cHM6Ly9zYW5kYm94LWFwaS5wYWRkbGUuY29tIiwiZW5hYmxlZCI6dHJ1ZSwidHlwZSI6ImRlZmF1bHQifSx7ImtleSI6ImJlYXJlclRva2VuIiwidmFsdWUiOiIiLCJlbmFibGVkIjp0cnVlLCJ0eXBlIjoic2VjcmV0In1d).
+
+![Logos for Go, Node.js, PHP, Python, Postman, and OpenAPI.](https://github.com/user-attachments/assets/12a7462f-d10d-412a-8465-efc94cb0f84a)
 
 ## We 💛 open source
 


### PR DESCRIPTION
Hey team 👋

Just a quick PR to update the hero image and text on our README to mirror the new dev docs homepage.

I also dropped in a grid of icons and swapped out the Postman link.

Cheers,
Michael
